### PR TITLE
Fixed the bug that causes dragging to select other entities

### DIFF
--- a/updated_game_v20.py
+++ b/updated_game_v20.py
@@ -100,18 +100,21 @@ class Game:
         elif event.type == pygame.MOUSEBUTTONUP:
             selecting = False
             end_pos = event.pos
-            self.deselect_entities(selected_entities)
-            dragged_entity = None
-            if start_pos == end_pos:
-                clicked_entity = next((entity for entity in entities if entity.contains_point(event.pos)), None)
-                if clicked_entity:
-                    selected_entities.extend(self.select_entities([clicked_entity], clicked_entity.shape))
+            # If an entity was being dragged, skip the selection rectangle logic
+            if dragged_entity:
+                dragged_entity = None
             else:
-                selection_rect = pygame.Rect(min(start_pos[0], end_pos[0]), 
-                                             min(start_pos[1], end_pos[1]), 
-                                             abs(start_pos[0] - end_pos[0]), 
-                                             abs(start_pos[1] - end_pos[1]))
-                selected_entities.extend(self.select_entities(entities, selection_rect))
+                self.deselect_entities(selected_entities)
+                if start_pos == end_pos:
+                    clicked_entity = next((entity for entity in entities if entity.contains_point(event.pos)), None)
+                    if clicked_entity:
+                        selected_entities.extend(self.select_entities([clicked_entity], clicked_entity.shape))
+                else:
+                    selection_rect = pygame.Rect(min(start_pos[0], end_pos[0]), 
+                                                min(start_pos[1], end_pos[1]), 
+                                                abs(start_pos[0] - end_pos[0]), 
+                                                abs(start_pos[1] - end_pos[1]))
+                    selected_entities.extend(self.select_entities(entities, selection_rect))
             start_pos = (0, 0)
             end_pos = None
         elif event.type == pygame.MOUSEMOTION and selecting:


### PR DESCRIPTION
I added a bit of logic to the handle_selection function, specifically in the MOUSEBUTTONUP case, that skips all of the rectangle selection logic if it sees that an entity is being dragged already.

Some point in the future we'll need to make the function a bit cleaner. But currently I am content to let it stay as is because I'm betting we won't have to add much more to this selection function. I think we have close to all the selection power we need for the time being.